### PR TITLE
Reduce the severity of auxilliary vector errors and fail safe

### DIFF
--- a/glib/gutils.c
+++ b/glib/gutils.c
@@ -3025,7 +3025,24 @@ g_check_setuid (void)
   value = getauxval (AT_SECURE);
   errsv = errno;
   if (errsv)
-    g_error ("getauxval () failed: %s", g_strerror (errsv));
+  {
+    /* When running 32-bit user applications on a 64-bit kernel, reading of the
+     * auxilliary vector can unreliable, likely as a result of the vector not
+     * being architecture agnostic.
+     *
+     * Whilst qemu-user appears to correct these structures depending on the
+     * target architecture, the glibc based loader for armhf (ld-2.27.so) used
+     * by the default toolchain included in the package respositories on Ubuntu
+     * 18.04 does not appear to do so (presumably as the same binary is used on
+     * both 32-bit and 64-bit kernels).
+     *
+     * Since an error results in everything stopping, we instead downgrade the
+     * message to a warning, but return TRUE (indicating that the application
+     * was setuid). Hence we assume the worst case scenario.
+     */
+    g_warning ("getauxval () failed: %s", g_strerror (errsv));
+    return TRUE;
+  }
   return value;
 #elif defined(HAVE_ISSETUGID) && !defined(__BIONIC__)
   /* BSD: http://www.freebsd.org/cgi/man.cgi?query=issetugid&sektion=2 */

--- a/glib/gutils.c
+++ b/glib/gutils.c
@@ -3024,25 +3024,24 @@ g_check_setuid (void)
   errno = 0;
   value = getauxval (AT_SECURE);
   errsv = errno;
+
+  /* When running 32-bit user applications on a 64-bit kernel, reading of the
+   * auxilliary vector can be unreliable, likely as a result of the vector not
+   * being architecture agnostic.
+   *
+   * Whilst qemu-user appears to correct these structures depending on the
+   * target architecture, the glibc based loader for armhf (ld-2.27.so) used by
+   * the default toolchain included in the package respositories on Ubuntu
+   * 18.04 does not appear to do so (presumably as the same binary is used on
+   * both 32-bit and 64-bit kernels).
+   *
+   * Since an error results in everything stopping, we instead downgrade the
+   * message to a warning, but return TRUE (indicating that the application was
+   * setuid). Hence we assume the worst case scenario.
+   */
   if (errsv)
-  {
-    /* When running 32-bit user applications on a 64-bit kernel, reading of the
-     * auxilliary vector can be unreliable, likely as a result of the vector not
-     * being architecture agnostic.
-     *
-     * Whilst qemu-user appears to correct these structures depending on the
-     * target architecture, the glibc based loader for armhf (ld-2.27.so) used
-     * by the default toolchain included in the package respositories on Ubuntu
-     * 18.04 does not appear to do so (presumably as the same binary is used on
-     * both 32-bit and 64-bit kernels).
-     *
-     * Since an error results in everything stopping, we instead downgrade the
-     * message to a warning, but return TRUE (indicating that the application
-     * was setuid). Hence we assume the worst case scenario.
-     */
-    g_warning ("getauxval () failed: %s", g_strerror (errsv));
     return TRUE;
-  }
+
   return value;
 #elif defined(HAVE_ISSETUGID) && !defined(__BIONIC__)
   /* BSD: http://www.freebsd.org/cgi/man.cgi?query=issetugid&sektion=2 */

--- a/glib/gutils.c
+++ b/glib/gutils.c
@@ -3027,7 +3027,7 @@ g_check_setuid (void)
   if (errsv)
   {
     /* When running 32-bit user applications on a 64-bit kernel, reading of the
-     * auxilliary vector can unreliable, likely as a result of the vector not
+     * auxilliary vector can be unreliable, likely as a result of the vector not
      * being architecture agnostic.
      *
      * Whilst qemu-user appears to correct these structures depending on the


### PR DESCRIPTION
Workaround for auxilliary vector failures when running 32-bit code on a 64-bit kernel.