### PR TITLE
Add GLIB_DYNAMIC_UNLOADING define

### DIFF
--- a/glib/glibconfig.h.in
+++ b/glib/glibconfig.h.in
@@ -18,6 +18,11 @@
  */
 #mesondefine GLIB_USING_SYSTEM_PRINTF
 
+/* Specifies that glib_init() is supported by this GLib
+ * build.
+ */
+#define GLIB_DYNAMIC_UNLOADING 1
+
 #mesondefine GLIB_STATIC_COMPILATION
 #mesondefine GOBJECT_STATIC_COMPILATION
 #mesondefine GIO_STATIC_COMPILATION


### PR DESCRIPTION
For GLib static builds, define a flag to determine if glib_init() is
supported by the current GLib build. This is useful for conditionally
building against different versions of GLib.