### PR TITLE
fix g_spawn apis not working on tvOS

### DIFF
--- a/glib/gspawn.c
+++ b/glib/gspawn.c
@@ -22,6 +22,23 @@
 
 #include "config.h"
 
+#ifdef __APPLE__
+# include <TargetConditionals.h>
+# if TARGET_OS_TV
+#  define HAVE_FORK 1
+#  define HAVE_POSIX_SPAWN 1
+#  include <Availability.h>
+#  undef __TVOS_PROHIBITED
+#  define __TVOS_PROHIBITED
+#  undef __API_UNAVAILABLE
+#  define __API_UNAVAILABLE(...)
+#  include <unistd.h>
+#  include <spawn.h>
+#  undef __TVOS_PROHIBITED
+#  define __TVOS_PROHIBITED __OS_AVAILABILITY(tvos,unavailable)
+# endif
+#endif
+
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/wait.h>


### PR DESCRIPTION
this manifested trying to run frida-core tests on tvOS

```
# Start of Injector tests

FAIL: Failed to fork (unsupported syscall)
```

cc https://github.com/frida/frida/pull/2500